### PR TITLE
Update README.md - small typo train_unfied -> train_unified

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ CUDA_VISIBLE_DEVICES=0 python3 src/train_arcface.py src/configs/cat.py  --output
 
 Also, you can train an arcface model on all the species (families):
 ```
-CUDA_VISIBLE_DEVICES=0 python3 src/train_unfied.py src/configs/unified.py  --output outputs/unified
+CUDA_VISIBLE_DEVICES=0 python3 src/train_unified.py src/configs/unified.py  --output outputs/unified
 ```
 
 # Acknowledgement


### PR DESCRIPTION
fix a small typo in README training section where file name "train_unified.py" is written as "train_unfied.py"